### PR TITLE
Remove backticks from scripts

### DIFF
--- a/music.js
+++ b/music.js
@@ -31,8 +31,7 @@ function chooseMusic() {
     prev = rand; // Set the previous song ID the new ID we just chose so the next time this script is run it will avoid this new ID.
 
     // Sets audio source to item "randomNum" of list "sources".
-    // The string is put in (Wattson) graves because it lets you put variables in between the strings by doing ${VARNAME}.
-    audioSrc.src = `about/music/music_${sources[rand]}.mp3`;
+    audioSrc.src = "about/music/music_" + sources[rand] + ".mp3";
     titleTxt.textContent = titles[rand]; // Sets "Now Playing" text to the item "randomNum" of list "titles".
     audioSrc.play();
 }

--- a/script.js
+++ b/script.js
@@ -241,7 +241,7 @@ function refreshSpearmint() {
     img.onload = hideLoadmint;
     div.classList.add("loadingmints");
     img.src = "spearmint/" + spearmints[rand];
-    artist.textContent = `by ${artists[rand]}`;
+    artist.textContent = "by " + artists[rand];
 }
 function onLoad() {
     img = document.getElementById("spearmint");


### PR DESCRIPTION
This removes backticks, also known as graves (the ` symbol) from scripts, which cannot be recognized by old JavaScript compilers like the one used in IE11. This improves the compatibility of the music player and random Spearmint generator.