### PR TITLE
Rename README stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# trickmint.github.io
+# mintsite
 
-the github page for my website
+the source code for my website


### PR DESCRIPTION
This changes trickmint.github.io to mintsite and github page to source code because I am irrationally upset.