### PR TITLE
Paint desktop version

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,10 @@
   </marquee>
 </div>
 
+<div id="mintversion">trickmint's website</div>
+<!-- Mint build date uses YYYY.MM.DD -->
+<div id="mintbuild">Build 2023.11.29</div>
+
 <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
   </marquee>
 </div>
 
-<div id="mintversion">trickmint's website</div>
+<div id="mintversion">mintsite</div>
 <!-- Mint build date uses YYYY.MM.DD -->
 <div id="mintbuild">Build 2023.11.29</div>
 

--- a/kinlist/index.html
+++ b/kinlist/index.html
@@ -73,6 +73,6 @@
     </div>
   </div>
 
-  <div id="mintversion">trickmint's website</div>
+  <div id="mintversion">mintsite</div>
   <!-- Mint build date uses YYYY.MM.DD -->
   <div id="mintbuild">Build 2023.11.29</div>

--- a/kinlist/index.html
+++ b/kinlist/index.html
@@ -72,3 +72,7 @@
       </center>
     </div>
   </div>
+
+  <div id="mintversion">trickmint's website</div>
+  <!-- Mint build date uses YYYY.MM.DD -->
+  <div id="mintbuild">Build 2023.11.29</div>

--- a/style.css
+++ b/style.css
@@ -48,3 +48,26 @@ html {
     justify-content: center;
     align-items: center;
     height: 200px}
+
+#mintversion, #mintbuild {
+    -moz-user-select: -moz-none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    font: 12px Segoe UI;
+    color: #fff;
+/* Fallback for browsers not using fixed positioning
+so that the text still aligns to the right anyway */
+    text-align: right
+}
+/* Not a good solution; some browsers support fixed positioning
+but not the @supports media query. This needs to be replaced */
+@supports (position: fixed) {
+    #mintversion, #mintbuild {
+        position: fixed;
+        right: 5px}
+    #mintversion {
+        bottom: 19px}
+    #mintbuild {
+        bottom: 1px}}


### PR DESCRIPTION
This paints the desktop version in the bottom-right corner of the page, similar to the Windows registry value of the same name, but the build date currently needs to be manually done.

This will display incorrectly on the kinlist page until merged due to how it loads stylesheets (https://github.com/trickmint/mintsite/issues/34).